### PR TITLE
Update `QemuBuilder` to latest and greatest.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+products/
+downloads/
+build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ sudo: required
 # Before anything else, get the latest versions of things
 before_script:
   - julia -e 'Pkg.clone("https://github.com/JuliaPackaging/BinaryProvider.jl")'
-  - julia -e 'Pkg.add("ObjectFile"); Pkg.checkout("ObjectFile")'
   - julia -e 'Pkg.clone("https://github.com/JuliaPackaging/BinaryBuilder.jl"); Pkg.build()'
 
 script:
@@ -33,7 +32,7 @@ deploy:
         # to make your own: https://docs.travis-ci.com/user/deployment/releases/
         secure: KKUt2b2196qPo9+ab7Ucvld5BR5NOQbSwrwIpjtyZjEmVGrFJYmGSuXeDHchMi8Anf0CXDYKqbXJTeF8S7gD6IzSzm6oyNj2aZ9pG/r6N0YTtEoNPixVzogqtqzBSZlsIgEzQhb5By679kdmPaFn74UX+Q5qvjppczOPruB/FToUFN6p/O9yLUr6pVmQYQjPG/bs+xT6vxCM4jsMcU4r+8NFy7r4CgGLIl6/3XFhYjcRkcadgSsC9HCWqSJbjgOPntyF6yIWDEjzZThCfywGnqmdX+uPFXbdqlRkQ312sl2cTmVJbEaxzfek6uKZQT8ObCPqb+Mscu5UWK5jGtG7nqL6xuz7z0uynv8+uKbu+f63hXhs1fVKnrstbqS4OTxSW9+Du4oTSUuFxwC7sCk7M2dypDduLt3GNS05e6ZAmnIqvZbjLExq5+giiqT4jDJn9jKFbpD1bRYSy/e8QEfuL4i4B2zk7ejlvDk+8FeDJzKBN/ttNbYJh9s6L/uPmLZnV+e7klPnMCap5h8N/Wux6Wo6qL7RUZNoNwhLxScnWFgAKUP1BpknzqE416y33LZ7GnindYMIGm6WfqGi4vsp4Y9RB4uItt3rI4f5uSkfL5O5MuHFqiuQ0mg7DUeOWXdlxzpb5WjyhplIjupetqTfGU1dWS7+pqlo+OV+EVJ8PWk=
     file_glob: true
-    file: products/*.tar.gz
+    file: products/*
     skip_cleanup: true
     on:
         repo: Keno/QemuBuilder

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -1,99 +1,16 @@
 using BinaryBuilder
 
-# These are the platforms built inside the wizard
-platforms = [
-    BinaryProvider.MacOS()
-]
-
-
-# If the user passed in a platform (or a few, comma-separated) on the
-# command-line, use that instead of our default platforms
-if length(ARGS) > 0
-    platforms = platform_key.(split(ARGS[1], ","))
-end
-info("Building for $(join(triplet.(platforms), ", "))")
-
-# Collection of sources required to build qemu
+# Collection of sources required to build libffi
 sources = [
-    "https://ftp.gnome.org/pub/gnome/sources/glib/2.54/glib-2.54.2.tar.xz" =>
-    "bb89e5c5aad33169a8c7f28b45671c7899c12f74caf707737f784d7102758e6c",
-    "https://zlib.net/zlib-1.2.11.tar.gz" =>
-    "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
-    "https://github.com/libffi/libffi.git" =>
-    "716bfd83177689e2244c4707bd513003cff92c68",
     "https://github.com/Keno/qemu.git" =>
     "d50ad0140fa674b0553ce63203a3eb9e56472e18",
 ]
 
+# Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir
-export PKG_CONFIG_PATH=$DESTDIR/lib/pkgconfig
-export PKG_CONFIG_SYSROOT_DIR=$DESTDIR
-apk add texinfo gettext
-cd zlib-1.2.11/
-./configure --prefix=/
-make install
-cd ../libffi
-./autogen.sh 
-./configure --prefix=/ --host=$target
-make -j40
-make install
-./configure --prefix=/ --host=$target
-cd ..
-cd libffi/
-make install
-cd ..
-curl -OL https://ftp.gnu.org/pub/gnu/gettext/gettext-0.19.8.tar.xz
-tar xof gettext-0.19.8.tar.xz 
-cd gettext-0.19.8
-./configure --prefix=/ --host=$target
-make -j40
-make install
-cd ..
-pwd
-curl -OL ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.41.tar.gz
-tar --no-same-owner -xzf pcre-8.41.tar.gz 
-cd pcre-8.41
-./configure --prefix=/ --host=$target
-make -j4
-make install
-cd ..
-cd glib-2.54.2/
-cat > glib.cache <<END
-glib_cv_stack_grows=no
-glib_cv_uscore=no
-END
-./configure --prefix=/ --cache-file=glib.cache --host=$target CPPFLAGS="-I$DESTDIR/include" "LDFLAGS=-L$DESTDIR/lib"
-make -j4
-make install
-curl -OL https://www.cairographics.org/releases/pixman-0.34.0.tar.gz
-tar xof pixman-0.34.0.tar.gz 
-cd pixman-0.34.0
-cat > clang.patch <<END
-diff --git a/configure.ac b/configure.ac
-index e833e45..cbebc82 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -1101,7 +1101,7 @@ support_for_gcc_vector_extensions=no
- AC_MSG_CHECKING(for GCC vector extensions)
- AC_LINK_IFELSE([AC_LANG_SOURCE([[
- unsigned int __attribute__ ((vector_size(16))) e, a, b;
--int main (void) { e = a - ((b << 27) + (b >> (32 - 27))) + 1; return e[0]; }
-+int main (void) { __builtin_shuffle(a,b);e = a - ((b << 27) + (b >> (32 - 27))) + 1; return e[0]; }
- ]])], support_for_gcc_vector_extensions=yes)
- 
- if test x$support_for_gcc_vector_extensions = xyes; then
--- 
-2.10.0
-END
+cd $WORKSPACE/srcdir/qemu
 
-patch < clang.patch 
-automake
-./configure --prefix=/ --host=$target
-make -j40
-make install
-cd $WORKSPACE/srcdir/qemu/
-cat > osx.patch <<END
+patch -p1 <<END
 diff --git a/hw/9pfs/9p-local.c b/hw/9pfs/9p-local.c
 index f49288f..5b8d6e6 100644
 --- a/hw/9pfs/9p-local.c
@@ -113,7 +30,6 @@ index f49288f..5b8d6e6 100644
      return ret;
 +#endif
  }
-
  static int local_unlinkat_common(FsContext *ctx, int dirfd, const char *name,
 
 diff --git a/hw/9pfs/9p.c b/hw/9pfs/9p.c
@@ -158,21 +74,42 @@ index daa8519..dea55e4 100644
          err = v9fs_co_chown(pdu, &fidp->path, v9stat.n_uid, v9stat.n_gid);
 END
 
-patch -p1 < osx.patch 
-./configure --extra-cflags="-target x86_64-apple-macosx10.7" --target-list=x86_64-softmmu --disable-cocoa
+./configure --extra-cflags="-target $target" --target-list=x86_64-softmmu --disable-cocoa --prefix=$prefix
 echo '#!/bin/true ' > /usr/bin/SetFile
 echo '#!/bin/true ' > /usr/bin/Rez
 chmod +x /usr/bin/Rez
 chmod +x /usr/bin/SetFile
-make -j4
+make -j${nproc}
 make install
-
 """
 
-products = prefix -> Product[
-    ExecutableProduct(prefix,"x86_64-softmmu/qemu-system-x86_64")
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    # For now, only build for MacOS
+    BinaryProvider.MacOS(),
 ]
 
-# Build the given platforms using the given sources
-autobuild(pwd(), "qemu", platforms, sources, script, products)
+# The products that we will ensure are always built
+products(prefix) = [
+    LibraryProduct(prefix, "x86_64-softmmu/qemu-system-x86_64", :qemu_x86_64)
+]
 
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    # We need Pixman
+    "https://github.com/staticfloat/PixmanBuilder/releases/download/v0.34.0-0/build.jl",
+    # We need Glib
+    "https://github.com/staticfloat/GlibBuilder/releases/download/v2.54.2-2/build.jl",
+    # We need Pcre
+    "https://github.com/staticfloat/PcreBuilder/releases/download/v8.41-0/build.jl",
+    # We need gettext
+    "https://github.com/staticfloat/GettextBuilder/releases/download/v0.19.8-0/build.jl",
+    # .....which needs libffi
+    "https://github.com/staticfloat/libffiBuilder/releases/download/v3.2.1-0/build.jl",
+    # .....which needs zlib
+    "https://github.com/staticfloat/ZlibBuilder/releases/download/v1.2.11-3/build.jl",
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, "Qemu", sources, script, platforms, products, dependencies)


### PR DESCRIPTION
Until https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/194 is
fixed, we have a slightly untidy `dependencies` section.  That will be
fixed eventually, so we only have to depend on the top-level
dependencies, and the rest will get transparently added/removed.